### PR TITLE
Obsidian.nvimがWindows環境でも動くようにする

### DIFF
--- a/neovim/nvim/lua/pl/nvim-cmp.lua
+++ b/neovim/nvim/lua/pl/nvim-cmp.lua
@@ -62,6 +62,9 @@ function M.config()
       { name = 'nvim_lsp_signature_help' },
       { name = 'vsnip' },
       { name = 'path' },
+      -- https://github.com/epwalsh/obsidian.nvim/issues/124
+      { name = "obsidian",               option = require 'pl.obsidian'.opt },
+      { name = "obsidian_new",           option = require 'pl.obsidian'.opt },
     }, {
       {
         name = 'buffer',

--- a/neovim/nvim/lua/pl/obsidian.lua
+++ b/neovim/nvim/lua/pl/obsidian.lua
@@ -1,124 +1,131 @@
 local M = {}
 
+M.opt = {
+  dir = '~/OneDrive/Obsidian/main',
+  -- Optional, if you keep notes in a specific subdirectory of your vault.
+  notes_subdir = 'Notes',
+
+  -- Optional, set the log level for obsidian.nvim. This is an integer corresponding to one of the log
+  -- levels defined by "vim.log.levels.*" or nil, which is equivalent to DEBUG (1).
+  log_level = vim.log.levels.DEBUG,
+
+  daily_notes = {
+    -- Optional, if you keep daily notes in a separate directory.
+    folder = 'デイリー',
+    -- Optional, if you want to change the date format for daily notes.
+    date_format = '%Y-%m-%d'
+  },
+
+  -- Optional, completion.
+  completion = {
+    -- If using nvim-cmp, otherwise set to false
+    nvim_cmp = true,
+    -- Trigger completion at 2 chars
+    min_chars = 2,
+    -- Where to put new notes created from completion. Valid options are
+    --  * "current_dir" - put new notes in same directory as the current buffer.
+    --  * "notes_subdir" - put new notes in the default notes subdirectory.
+    new_notes_location = 'notes_subdir',
+
+    -- Whether to add the output of the node_id_func to new notes in autocompletion.
+    -- E.g. "[[Foo" completes to "[[foo|Foo]]" assuming "foo" is the ID of the note.
+    prepend_note_id = true
+  },
+
+  -- Optional, key mappings.
+  mappings = {
+    -- Overrides the 'gf' mapping to work on markdown/wiki links within your vault.
+    -- ['gf'] = require 'obsidian.mapping'.gf_passthrough(),
+  },
+
+  -- Optional, customize how names/IDs for new notes are created.
+  note_id_func = function(title)
+    -- Create note IDs in a Zettelkasten format with a timestamp and a suffix.
+    -- In this case a note with the title 'My new note' will given an ID that looks
+    -- like '1657296016-my-new-note', and therefore the file name '1657296016-my-new-note.md'
+    local suffix = ""
+    if title ~= nil then
+      -- If title is given, transform it into valid file name.
+      suffix = title:gsub(" ", "-"):gsub("[^A-Za-z0-9-]", ""):lower()
+    else
+      -- If title is nil, just add 4 random uppercase letters to the suffix.
+      for _ = 1, 4 do
+        suffix = suffix .. string.char(math.random(65, 90))
+      end
+    end
+    -- そのまま
+    return title
+    -- return tostring(os.time()) .. "-" .. suffix
+  end,
+
+  -- Optional, set to true if you don't want obsidian.nvim to manage frontmatter.
+  disable_frontmatter = false,
+
+  -- Optional, alternatively you can customize the frontmatter data.
+  note_frontmatter_func = function(note)
+    -- This is equivalent to the default frontmatter function.
+    local out = { id = note.id, aliases = note.aliases, tags = note.tags }
+    -- `note.metadata` contains any manually added fields in the frontmatter.
+    -- So here we just make sure those fields are kept in the frontmatter.
+    if note.metadata ~= nil and require 'obsidian'.util.table_length(note.metadata) > 0 then
+      for k, v in pairs(note.metadata) do
+        out[k] = v
+      end
+    end
+    return out
+  end,
+
+  -- Optional, for templates (see below).
+  templates = {
+    subdir = '_templates',
+    date_format = '%Y-%m-%d-%a',
+    time_format = '%H:%M',
+  },
+
+  -- Optional, customize the backlinks interface.
+  backlinks = {
+    -- The default height of the backlinks pane.
+    height = 10,
+    -- Whether or not to wrap lines.
+    wrap = true,
+  },
+
+  -- Optional, by default when you use `:ObsidianFollowLink` on a link to an external
+  -- URL it will be ignored but you can customize this behavior here.
+  follow_url_func = function(url)
+    -- Open the URL in the default web browser.
+    if vim.fn.has 'unix' == 1 then
+      vim.fn.jobstart { 'xdg-open', url }
+    elseif vim.fn.has 'win32' == 1 then
+      vim.fn.jobstart { 'explorer.exe', url }
+    else
+      vim.fn.jobstart { 'open', url }
+    end
+  end,
+
+  -- Optional, set to true if you use the Obsidian Advanced URI plugin.
+  -- https://github.com/Vinzent03/obsidian-advanced-uri
+  use_advanced_uri = true,
+
+  -- Optional, set to true to force ':ObsidianOpen' to bring the app to the foreground.
+  open_app_foreground = false,
+
+  -- Optional, by default commands like `:ObsidianSearch` will attempt to use
+  -- telescope.nvim, fzf-lua, and fzf.nvim (in that order), and use the
+  -- first one they find. By setting this option to your preferred
+  -- finder you can attempt it first. Note that if the specified finder
+  -- is not installed, or if it the command does not support it, the
+  -- remaining finders will be attempted in the original order.
+  finder = 'telescope.nvim',
+
+  -- Optional, determines whether to open notes in a horizontal split, a vertical split,
+  -- or replacing the current buffer (default)
+  -- Accepted values are "current", "hsplit" and "vsplit"
+  open_notes_in = 'current'
+}
+
 function M.config()
-  require 'obsidian'.setup {
-    dir = '~/OneDrive/Obsidian/main',
-    -- Optional, if you keep notes in a specific subdirectory of your vault.
-    notes_subdir = 'Notes',
-
-    -- Optional, set the log level for obsidian.nvim. This is an integer corresponding to one of the log
-    -- levels defined by "vim.log.levels.*" or nil, which is equivalent to DEBUG (1).
-    log_level = vim.log.levels.DEBUG,
-
-    daily_notes = {
-      -- Optional, if you keep daily notes in a separate directory.
-      folder = 'デイリー',
-      -- Optional, if you want to change the date format for daily notes.
-      date_format = '%Y-%m-%d'
-    },
-
-    -- Optional, completion.
-    completion = {
-      -- If using nvim-cmp, otherwise set to false
-      nvim_cmp = true,
-      -- Trigger completion at 2 chars
-      min_chars = 2,
-      -- Where to put new notes created from completion. Valid options are
-      --  * "current_dir" - put new notes in same directory as the current buffer.
-      --  * "notes_subdir" - put new notes in the default notes subdirectory.
-      new_notes_location = 'notes_subdir',
-
-      -- Whether to add the output of the node_id_func to new notes in autocompletion.
-      -- E.g. "[[Foo" completes to "[[foo|Foo]]" assuming "foo" is the ID of the note.
-      prepend_note_id = true
-    },
-
-    -- Optional, key mappings.
-    mappings = {
-      -- Overrides the 'gf' mapping to work on markdown/wiki links within your vault.
-      -- ['gf'] = require 'obsidian.mapping'.gf_passthrough(),
-    },
-
-    -- Optional, customize how names/IDs for new notes are created.
-    note_id_func = function(title)
-      -- Create note IDs in a Zettelkasten format with a timestamp and a suffix.
-      -- In this case a note with the title 'My new note' will given an ID that looks
-      -- like '1657296016-my-new-note', and therefore the file name '1657296016-my-new-note.md'
-      local suffix = ""
-      if title ~= nil then
-        -- If title is given, transform it into valid file name.
-        suffix = title:gsub(" ", "-"):gsub("[^A-Za-z0-9-]", ""):lower()
-      else
-        -- If title is nil, just add 4 random uppercase letters to the suffix.
-        for _ = 1, 4 do
-          suffix = suffix .. string.char(math.random(65, 90))
-        end
-      end
-      -- そのまま
-      return title
-      -- return tostring(os.time()) .. "-" .. suffix
-    end,
-
-    -- Optional, set to true if you don't want obsidian.nvim to manage frontmatter.
-    disable_frontmatter = false,
-
-    -- Optional, alternatively you can customize the frontmatter data.
-    note_frontmatter_func = function(note)
-      -- This is equivalent to the default frontmatter function.
-      local out = { id = note.id, aliases = note.aliases, tags = note.tags }
-      -- `note.metadata` contains any manually added fields in the frontmatter.
-      -- So here we just make sure those fields are kept in the frontmatter.
-      if note.metadata ~= nil and require 'obsidian'.util.table_length(note.metadata) > 0 then
-        for k, v in pairs(note.metadata) do
-          out[k] = v
-        end
-      end
-      return out
-    end,
-
-    -- Optional, for templates (see below).
-    templates = {
-      subdir = '_templates',
-      date_format = '%Y-%m-%d-%a',
-      time_format = '%H:%M',
-    },
-
-    -- Optional, customize the backlinks interface.
-    backlinks = {
-      -- The default height of the backlinks pane.
-      height = 10,
-      -- Whether or not to wrap lines.
-      wrap = true,
-    },
-
-    -- Optional, by default when you use `:ObsidianFollowLink` on a link to an external
-    -- URL it will be ignored but you can customize this behavior here.
-    follow_url_func = function(url)
-      -- Open the URL in the default web browser.
-      --vim.fn.jobstart{ 'open', url } -- Mac OS
-      vim.fn.jobstart { 'xdg-open', url } -- linux
-    end,
-
-    -- Optional, set to true if you use the Obsidian Advanced URI plugin.
-    -- https://github.com/Vinzent03/obsidian-advanced-uri
-    use_advanced_uri = true,
-
-    -- Optional, set to true to force ':ObsidianOpen' to bring the app to the foreground.
-    open_app_foreground = false,
-
-    -- Optional, by default commands like `:ObsidianSearch` will attempt to use
-    -- telescope.nvim, fzf-lua, and fzf.nvim (in that order), and use the
-    -- first one they find. By setting this option to your preferred
-    -- finder you can attempt it first. Note that if the specified finder
-    -- is not installed, or if it the command does not support it, the
-    -- remaining finders will be attempted in the original order.
-    finder = 'telescope.nvim',
-
-    -- Optional, determines whether to open notes in a horizontal split, a vertical split,
-    -- or replacing the current buffer (default)
-    -- Accepted values are "current", "hsplit" and "vsplit"
-    open_notes_in = 'current'
-  }
+  require 'obsidian'.setup(M.opt)
 end
 
 return M

--- a/neovim/nvim/lua/rc/plugins.lua
+++ b/neovim/nvim/lua/rc/plugins.lua
@@ -319,6 +319,7 @@ local plugins = {
     },
     dependencies = {
       'nvim-lua/plenary.nvim',
+      'hrsh7th/nvim-cmp',
     },
     config = require 'pl.obsidian'.config,
   },

--- a/neovim/nvim/lua/rc/plugins.lua
+++ b/neovim/nvim/lua/rc/plugins.lua
@@ -314,8 +314,8 @@ local plugins = {
     'epwalsh/obsidian.nvim',
     lazy = true,
     event = {
-      'BufReadPre ' .. vim.fn.expand '~' .. '/OneDrive/Obsidian/main/**.md',
-      'BufNewFile ' .. vim.fn.expand '~' .. '/OneDrive/Obsidian/main/**.md',
+      'BufReadPre ' .. (vim.fn.expand '~'):gsub('\\', '/') .. '/OneDrive/Obsidian/main/**.md',
+      'BufReadPre ' .. (vim.fn.expand '~'):gsub('\\', '/') .. '/OneDrive/Obsidian/main/**.md',
     },
     dependencies = {
       'nvim-lua/plenary.nvim',


### PR DESCRIPTION
- Windows環境ではvim.fn.expand('~')のパス区切りが`\\`だが、イベントのパターン指定では常に`/`を使う必要があるので`\\`を`/`に置き換える
- なぜか補完ソースが自動で登録されないので手動で登録する
