### PR TITLE
lazy-lock.jsonの改行コードはLFとする

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+lazy-lock.json        text eol=lf


### PR DESCRIPTION
ただしWindowsでチェックアウトした場合はCRLFとする